### PR TITLE
add description to package.json

### DIFF
--- a/Libraries/RNWatch/package.json
+++ b/Libraries/RNWatch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-watch-connectivity",
   "version": "0.2.0",
+  "description": "Enable communication between iWatch app and react native",
   "main": "./RNWatch.ios.build.js",
   "keywords": "react-native",
   "repository": {


### PR DESCRIPTION
currently, `react-native link` fails with the following error:

```
 `RNWatch` pod failed to validate due to 1 error attributes: Missing required attribute `summary`
```

`s.summary` is set to `package['description']`, but the corresponding `package.json` file is missing a `description` field. This PR fixes that.