### PR TITLE
add subscribeToReachability back to the library

### DIFF
--- a/lib/reachability.ts
+++ b/lib/reachability.ts
@@ -1,5 +1,13 @@
 import {NativeModule} from './native-module';
+import watchEvents, { UnsubscribeFn } from './events';
+
 
 export function getReachability(): Promise<boolean> {
   return NativeModule.getReachability();
+}
+
+
+export function subscribeToReachability(callback: (reachable: boolean) => void): UnsubscribeFn {
+  NativeModule.getReachability().then(callback)
+  return watchEvents.addListener('reachability', callback)
 }


### PR DESCRIPTION
I was reading the documentation and subscribeToReachability is not available in latest versions, I don't know if you accidentally removed it or something, but that's how I implemented it back in my project