### PR TITLE
Delay event firing until there's a listener

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -218,7 +218,9 @@ RCT_EXPORT_METHOD(replyToMessageWithId:
             (NSDictionary<NSString *, id> *) message) {
     void (^replyHandler)(NSDictionary<NSString *, id> *_Nonnull)
     = [self.replyHandlers objectForKey:messageId];
-    replyHandler(message);
+    if (replyHandler != nil) {
+        replyHandler(message);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Even if the listeners are registered as quickly as possible on the JS side, it's still possible that it may miss some events emitted. The best practice is to queue them up and fire only after the first listener has been registered. See https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript for more details.  

Also fixed a crashing issue calling a null message reply handler due to cache purge.