### PR TITLE
fix: Endless user info event loop when using addListener

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -482,7 +482,10 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
     for (NSString *ident in ids) {
         [self.queuedUserInfo removeObjectForKey:ident];
     }
-    [self dispatchEventWithName:EVENT_WATCH_USER_INFO_RECEIVED body:self.queuedUserInfo];
+
+    if (!ids || !ids.count){
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_RECEIVED body:self.queuedUserInfo];
+    }
 }
 
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {


### PR DESCRIPTION
When `user-info` listener is attached the library goes into an endless loop.

While receiving `EVENT_WATCH_USER_INFO_RECEIVED` event, listener's callback invokes `_dequeueUserInfo(item)` method, which in turn call its counterpart on the native side `dequeueUserInfo`.

This function sends the `EVENT_WATCH_USER_INFO_RECEIVED` regardless if there are dequeued infos, resulting in `payload: null` and an endless loop.