### PR TITLE
Print warning if the User Info Transfer fails

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -486,6 +486,9 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 }
 
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
+    if (error) {
+        NSLog(@"Error: %@ %@", error, [error userInfo]);
+    }
     // TODO
 }
 


### PR DESCRIPTION
At the moment, if a User Info Transfer from the Phone to the Watch fails, the developer does not see any warning or error message, because of the following `TODO` in `RNWatch.m`:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/1302357/167860638-377223c9-521a-48c4-9681-77e935e91d1e.png">

We should at least see an `NSLog` warning, otherwise debugging can get pretty cumbersome.