### PR TITLE
Propagate connectivity errors over the bridge

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -36,6 +36,7 @@ static NSString *EVENT_SESSION_DID_DEACTIVATE = @"WatchSessionDidDeactivate";
 static NSString *EVENT_SESSION_BECAME_INACTIVE = @"WatchSessionBecameInactive";
 static NSString *EVENT_PAIR_STATUS_CHANGED = @"WatchPairStatusChanged";
 static NSString *EVENT_INSTALL_STATUS_CHANGED = @"WatchInstallStatusChanged";
+static NSString *EVENT_WATCH_SEND_ERROR = @"WatchSendError";
 
 static RNWatch *sharedInstance;
 
@@ -92,6 +93,7 @@ RCT_EXPORT_MODULE()
             EVENT_INSTALL_STATUS_CHANGED,
             EVENT_SESSION_BECAME_INACTIVE,
             EVENT_SESSION_DID_DEACTIVATE,
+            EVENT_SEND_ERROR,
     ];
 }
 
@@ -427,7 +429,12 @@ didFinishFileTransfer:(WCSessionFileTransfer *)fileTransfer
 
 RCT_EXPORT_METHOD(updateApplicationContext:
     (NSDictionary<NSString *, id> *) context) {
-    [self.session updateApplicationContext:context error:nil];
+    NSError *error = nil;
+    [self.session updateApplicationContext:context error:&error];
+    if (error) {
+        NSLog(@"Application context update error: %@ %@", error, [error userInfo]);
+        [self dispatchEventWithName:EVENT_WATCH_SEND_ERROR body:@{@"context": context, @"error": error}];
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -493,8 +500,8 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
         NSLog(@"Error: %@ %@", error, [error userInfo]);
+        [self dispatchEventWithName:EVENT_WATCH_SEND_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": error}];
     }
-    // TODO
 }
 
 - (void)   session:(WCSession *)session

--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -36,7 +36,8 @@ static NSString *EVENT_SESSION_DID_DEACTIVATE = @"WatchSessionDidDeactivate";
 static NSString *EVENT_SESSION_BECAME_INACTIVE = @"WatchSessionBecameInactive";
 static NSString *EVENT_PAIR_STATUS_CHANGED = @"WatchPairStatusChanged";
 static NSString *EVENT_INSTALL_STATUS_CHANGED = @"WatchInstallStatusChanged";
-static NSString *EVENT_WATCH_SEND_ERROR = @"WatchSendError";
+static NSString *EVENT_WATCH_USER_INFO_ERROR = @"WatchUserInfoError";
+static NSString *EVENT_WATCH_APPLICATION_CONTEXT_ERROR = @"WatchAppContextError";
 
 static RNWatch *sharedInstance;
 
@@ -93,7 +94,8 @@ RCT_EXPORT_MODULE()
             EVENT_INSTALL_STATUS_CHANGED,
             EVENT_SESSION_BECAME_INACTIVE,
             EVENT_SESSION_DID_DEACTIVATE,
-            EVENT_SEND_ERROR,
+            EVENT_WATCH_USER_INFO_ERROR,
+            EVENT_WATCH_APPLICATION_CONTEXT_ERROR
     ];
 }
 
@@ -433,7 +435,7 @@ RCT_EXPORT_METHOD(updateApplicationContext:
     [self.session updateApplicationContext:context error:&error];
     if (error) {
         NSLog(@"Application context update error: %@ %@", error, [error userInfo]);
-        [self dispatchEventWithName:EVENT_WATCH_SEND_ERROR body:@{@"context": context, @"error": error}];
+        [self dispatchEventWithName:EVENT_WATCH_APPLICATION_CONTEXT_ERROR body:@{@"context": context, @"error": error}];
     }
 }
 
@@ -500,7 +502,7 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
         NSLog(@"Error: %@ %@", error, [error userInfo]);
-        [self dispatchEventWithName:EVENT_WATCH_SEND_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": error}];
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": error}];
     }
 }
 

--- a/lib/events/definitions.ts
+++ b/lib/events/definitions.ts
@@ -29,7 +29,8 @@ export interface WatchEventCallbacks<
   paired: (paired: boolean) => void;
   reachability: (reachable: boolean) => void;
   'user-info': (payload: P[]) => void;
-  'send-error': (payload: P) => void;
+  'application-context-error': (payload: P) => void;
+  'user-info-error': (payload: P) => void;
 }
 
 export type WatchEvent = keyof WatchEventCallbacks;

--- a/lib/events/definitions.ts
+++ b/lib/events/definitions.ts
@@ -29,6 +29,7 @@ export interface WatchEventCallbacks<
   paired: (paired: boolean) => void;
   reachability: (reachable: boolean) => void;
   'user-info': (payload: P[]) => void;
+  'send-error': (payload: P) => void;
 }
 
 export type WatchEvent = keyof WatchEventCallbacks;

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -7,6 +7,7 @@ import {
   _subscribeToNativeInstalledEvent,
   _subscribeToNativePairedEvent,
   _subscribeToNativeReachabilityEvent,
+  _subscribeNativeSendErrorEvent,
   AddListenerFn,
 } from './subscriptions';
 import {_addListener, _once, WatchPayload} from '../native-module';
@@ -33,6 +34,8 @@ function listen<E extends WatchEvent>(
       return _subscribeToNativePairedEvent(cb, listener);
     case 'installed':
       return _subscribeToNativeInstalledEvent(cb, listener);
+    case 'send-error':
+      return _subscribeNativeSendErrorEvent(cb, listener);
     default:
       throw new Error(`Unknown watch event "${event}"`);
   }
@@ -76,6 +79,11 @@ function addListener(
 function addListener(
   event: 'installed',
   cb: WatchEventCallbacks['installed'],
+): UnsubscribeFn;
+
+function addListener<Context extends WatchPayload = WatchPayload>(
+  event: 'send-error',
+  cb: WatchEventCallbacks<Context>['send-error'],
 ): UnsubscribeFn;
 
 function addListener(event: WatchEvent, cb: any): UnsubscribeFn {
@@ -149,6 +157,15 @@ function once(
 function once(
   event: 'installed',
 ): Promise<Parameters<WatchEventCallbacks['installed']>[0]>;
+
+function once<Context extends WatchPayload = WatchPayload>(
+  event: 'send-error',
+  cb: WatchEventCallbacks<Context>['send-error'],
+): UnsubscribeFn;
+
+function once<Context extends WatchPayload = WatchPayload>(
+  event: 'send-error',
+): Promise<Parameters<WatchEventCallbacks<Context>['send-error']>[0]>;
 
 function once(event: WatchEvent, cb?: any): UnsubscribeFn | Promise<any> {
   if (cb) {

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -7,7 +7,8 @@ import {
   _subscribeToNativeInstalledEvent,
   _subscribeToNativePairedEvent,
   _subscribeToNativeReachabilityEvent,
-  _subscribeNativeSendErrorEvent,
+  _subscribeNativeApplicationContextErrorEvent,
+  _subscribeNativeUserInfoErrorEvent,
   AddListenerFn,
 } from './subscriptions';
 import {_addListener, _once, WatchPayload} from '../native-module';
@@ -34,8 +35,10 @@ function listen<E extends WatchEvent>(
       return _subscribeToNativePairedEvent(cb, listener);
     case 'installed':
       return _subscribeToNativeInstalledEvent(cb, listener);
-    case 'send-error':
-      return _subscribeNativeSendErrorEvent(cb, listener);
+    case 'application-context-error':
+      return _subscribeNativeApplicationContextErrorEvent(cb, listener);
+    case 'user-info-error':
+      return _subscribeNativeUserInfoErrorEvent(cb, listener);
     default:
       throw new Error(`Unknown watch event "${event}"`);
   }
@@ -82,8 +85,13 @@ function addListener(
 ): UnsubscribeFn;
 
 function addListener<Context extends WatchPayload = WatchPayload>(
-  event: 'send-error',
-  cb: WatchEventCallbacks<Context>['send-error'],
+  event: 'application-context-error',
+  cb: WatchEventCallbacks<Context>['application-context-error'],
+): UnsubscribeFn;
+
+function addListener<Context extends WatchPayload = WatchPayload>(
+  event: 'user-info-error',
+  cb: WatchEventCallbacks<Context>['user-info-error'],
 ): UnsubscribeFn;
 
 function addListener(event: WatchEvent, cb: any): UnsubscribeFn {
@@ -159,13 +167,22 @@ function once(
 ): Promise<Parameters<WatchEventCallbacks['installed']>[0]>;
 
 function once<Context extends WatchPayload = WatchPayload>(
-  event: 'send-error',
-  cb: WatchEventCallbacks<Context>['send-error'],
+  event: 'application-context-error',
+  cb: WatchEventCallbacks<Context>['application-context-error'],
 ): UnsubscribeFn;
 
 function once<Context extends WatchPayload = WatchPayload>(
-  event: 'send-error',
-): Promise<Parameters<WatchEventCallbacks<Context>['send-error']>[0]>;
+  event: 'application-context-error',
+): Promise<Parameters<WatchEventCallbacks<Context>['application-context-error']>[0]>;
+
+function once<Context extends WatchPayload = WatchPayload>(
+  event: 'user-info-error',
+  cb: WatchEventCallbacks<Context>['user-info-error'],
+): UnsubscribeFn;
+
+function once<Context extends WatchPayload = WatchPayload>(
+  event: 'user-info-error',
+): Promise<Parameters<WatchEventCallbacks<Context>['user-info-error']>[0]>;
 
 function once(event: WatchEvent, cb?: any): UnsubscribeFn | Promise<any> {
   if (cb) {

--- a/lib/events/subscriptions.ts
+++ b/lib/events/subscriptions.ts
@@ -135,3 +135,10 @@ export function _subscribeToNativeInstalledEvent(
     cb(installed);
   });
 }
+
+export function _subscribeNativeSendErrorEvent(
+  cb: WatchEventCallbacks['send-error'],
+  addListener: AddListenerFn = _addListener,
+) {
+  return addListener(WatchEvent.EVENT_WATCH_SEND_ERROR, cb);
+}

--- a/lib/events/subscriptions.ts
+++ b/lib/events/subscriptions.ts
@@ -136,9 +136,16 @@ export function _subscribeToNativeInstalledEvent(
   });
 }
 
-export function _subscribeNativeSendErrorEvent(
-  cb: WatchEventCallbacks['send-error'],
+export function _subscribeNativeApplicationContextErrorEvent(
+  cb: WatchEventCallbacks['application-context-error'],
   addListener: AddListenerFn = _addListener,
 ) {
-  return addListener(WatchEvent.EVENT_WATCH_SEND_ERROR, cb);
+  return addListener(WatchEvent.EVENT_WATCH_APPLICATION_CONTEXT_ERROR, cb);
+}
+
+export function _subscribeNativeUserInfoErrorEvent(
+  cb: WatchEventCallbacks['user-info-error'],
+  addListener: AddListenerFn = _addListener,
+) {
+  return addListener(WatchEvent.EVENT_WATCH_USER_INFO_ERROR, cb);
 }

--- a/lib/native-module.ts
+++ b/lib/native-module.ts
@@ -106,7 +106,8 @@ export enum WatchEvent {
   EVENT_WATCH_REACHABILITY_CHANGED = 'WatchReachabilityChanged',
   EVENT_WATCH_STATE_CHANGED = 'WatchStateChanged',
   EVENT_WATCH_USER_INFO_RECEIVED = 'WatchUserInfoReceived',
-  EVENT_WATCH_SEND_ERROR = 'WatchSendError',
+  EVENT_WATCH_APPLICATION_CONTEXT_ERROR = 'WatchApplicationContextError',
+  EVENT_WATCH_USER_INFO_ERROR = 'WatchUserInfoError',
 }
 
 export interface EventPayloads {
@@ -129,6 +130,8 @@ export interface EventPayloads {
   [WatchEvent.EVENT_INSTALL_STATUS_CHANGED]: {
     installed: boolean;
   };
+  [WatchEvent.EVENT_WATCH_APPLICATION_CONTEXT_ERROR]: Error;
+  [WatchEvent.EVENT_WATCH_USER_INFO_ERROR]: Error;
 }
 
 export function _addListener<E extends WatchEvent, Payload = EventPayloads[E]>(

--- a/lib/native-module.ts
+++ b/lib/native-module.ts
@@ -106,6 +106,7 @@ export enum WatchEvent {
   EVENT_WATCH_REACHABILITY_CHANGED = 'WatchReachabilityChanged',
   EVENT_WATCH_STATE_CHANGED = 'WatchStateChanged',
   EVENT_WATCH_USER_INFO_RECEIVED = 'WatchUserInfoReceived',
+  EVENT_WATCH_SEND_ERROR = 'WatchSendError',
 }
 
 export interface EventPayloads {


### PR DESCRIPTION
@mtford90 @walterholohan As discussed in #85, we need to propagate the errors from the native to the Javascript side.

I have tried to implement this, but I currently cannot test it. Both on my iMac and my Macbook, I'm getting the error [described here](https://stackoverflow.com/questions/63261150/yogakit-modulemap-not-found-after-running-the-ios-simulator) when building the example project for the simulator or a device. All the solutions mentioned on Stackoverflow did not help me. Maybe I'm doing something basically wrong, I'm not experienced with Xcode.

Also, my mobx knowledge is not sufficient to extend the example with its integration tests.

I see three options to advance this:

* One of you finds the time to extend the example project, so that the back-propagation of errors over the bridge is tested (for User Info as well as Application Context).
* One of you helps me build the project, and tells me where to easily extend the integration test.
* If those options don't work for you, maybe @walterholohan you could test it on your project, the one where you tried to pass `null` to the Watch, see #77? If it works in that case, we might merge the PR without an integration test.

fixes #85 