### PR TITLE
Fix event name

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -37,7 +37,7 @@ static NSString *EVENT_SESSION_BECAME_INACTIVE = @"WatchSessionBecameInactive";
 static NSString *EVENT_PAIR_STATUS_CHANGED = @"WatchPairStatusChanged";
 static NSString *EVENT_INSTALL_STATUS_CHANGED = @"WatchInstallStatusChanged";
 static NSString *EVENT_WATCH_USER_INFO_ERROR = @"WatchUserInfoError";
-static NSString *EVENT_WATCH_APPLICATION_CONTEXT_ERROR = @"WatchAppContextError";
+static NSString *EVENT_WATCH_APPLICATION_CONTEXT_ERROR = @"WatchApplicationContextError";
 
 static RNWatch *sharedInstance;
 


### PR DESCRIPTION
Seems in my PR #90 I mistyped an event name. Sorry for that, but as I said I'm currently unable to test this library when it is not released.

This PR fixes that.