### PR TITLE
Propagate NSError.userInfo property instead of whole NSError

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -501,7 +501,7 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
-        NSLog(@"Error: %@ %@", error, [error userInfo]);
+        NSLog(@"User info transfer error: %@ %@", error, [error userInfo]);
         [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": [userInfoTransfer userInfo], @"error": [error userInfo]}];
     }
 }

--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -502,7 +502,7 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
         NSLog(@"Error: %@ %@", error, [error userInfo]);
-        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": [error userInfo]}];
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": [userInfoTransfer userInfo], @"error": [error userInfo]}];
     }
 }
 

--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -435,7 +435,7 @@ RCT_EXPORT_METHOD(updateApplicationContext:
     [self.session updateApplicationContext:context error:&error];
     if (error) {
         NSLog(@"Application context update error: %@ %@", error, [error userInfo]);
-        [self dispatchEventWithName:EVENT_WATCH_APPLICATION_CONTEXT_ERROR body:@{@"context": context, @"error": error}];
+        [self dispatchEventWithName:EVENT_WATCH_APPLICATION_CONTEXT_ERROR body:@{@"context": context, @"error": [error userInfo]}];
     }
 }
 
@@ -502,7 +502,7 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
         NSLog(@"Error: %@ %@", error, [error userInfo]);
-        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": error}];
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfoTransfer": userInfoTransfer, @"error": [error userInfo]}];
     }
 }
 


### PR DESCRIPTION
In my tests, the `NSError` object does not get transferred from the native side over the bridge. Even though the `error` key of the dictionary is set to the error on the native side, it always ends up being `null` on the Javascript side.

It looks to me as if `NSError` is something that is not meant to be sent over the bridge. Does anyone understand more about this to confirm or reject this @mtford90 @walterholohan ?

Anyway, things look much better if we transfer `[error userInfo]` instead of the whole error. This is a `NSDictionary` instance that, for example, holds the following information:

```
{
  "NSLocalizedRecoverySuggestion": "Only pass valid types.",
  "NSLocalizedDescription": "Payload contains unsupported type."
}
```

In my tests, the `NSError` object did not contain more information than this, so we might as well just pass that.

Same goes for the `userInfoTransfer` object, which always ended up being `null` on the Javascript side, so I now just transfer `[userInfoTransfer userInfo]`, which is exactly the User Info object that we tried to pass to the watch.