### PR TITLE
feat: stub out hooks in android so it doesnt crash android app

### DIFF
--- a/lib/RNWatch.android.ts
+++ b/lib/RNWatch.android.ts
@@ -11,6 +11,10 @@ const RNWatch = {
   test: function () {
     warning('Not supported on Android.');
   },
+  useInstalled: false,
+  usePaired: false,
+  useReachability: false,
+  useApplicationContext: false,
 };
 
 export default RNWatch;

--- a/lib/RNWatch.android.ts
+++ b/lib/RNWatch.android.ts
@@ -11,10 +11,10 @@ const RNWatch = {
   test: function () {
     warning('Not supported on Android.');
   },
-  useInstalled: false,
-  usePaired: false,
-  useReachability: false,
-  useApplicationContext: false,
+  useInstalled: () => false,
+  usePaired: () => false,
+  useReachability: () => false,
+  useApplicationContext: () => false,
 };
 
 export default RNWatch;


### PR DESCRIPTION
I've run into a problem where I have a screen that use's `useInstalled` and `usePaired` but it crashes on Android as the hooks are undefined. My initial thought was the wrap them in a `if (Platform.OS === 'ios') {}` but in React you should not wrap hooks in a conditional. The other option is to just return false for these functions in Android