### PR TITLE
add stub RNWatch for web

### DIFF
--- a/lib/RNWatch.web.ts
+++ b/lib/RNWatch.web.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub of RNWatch for Web.
+ *
+ * @providesModule RNWatch
+ */
+'use strict';
+
+export const useInstalled = () => false;
+export const usePaired = () => false;
+export const useReachability = () => false;
+export const useApplicationContext = () => false;


### PR DESCRIPTION
To make expo projects using this library work on web, the following stud is needed.