### PR TITLE
Ensure handling of nil dictionaries in didFinishUserInfoTransfer

### DIFF
--- a/ios/RNWatch/RNWatch.m
+++ b/ios/RNWatch/RNWatch.m
@@ -574,8 +574,15 @@ RCT_EXPORT_METHOD(dequeueUserInfo:
 
 - (void)session:(WCSession *)session didFinishUserInfoTransfer:(WCSessionUserInfoTransfer *)userInfoTransfer error:(NSError *)error {
     if (error) {
-        NSLog(@"User info transfer error: %@ %@", error, [error userInfo]);
-      [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": [userInfoTransfer userInfo], @"error": dictionaryFromError(error)}];
+	NSLog(@"User info transfer error: %@ %@", error, [error userInfo]);
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": [userInfoTransfer userInfo], @"error": [error userInfo]}];
+        
+	NSDictionary *errorUserInfo = [error userInfo];
+        NSDictionary *transferUserInfo = [userInfoTransfer userInfo];
+        NSLog(@"User info transfer error: %@ %@", error, errorUserInfo);
+
+        // Use empty dictionaries as fallback since NSDictionary literals cannot contain nil
+        [self dispatchEventWithName:EVENT_WATCH_USER_INFO_ERROR body:@{@"userInfo": transferUserInfo ?: @{}, @"error": errorUserInfo ?: @{}}];
     }
 }
 


### PR DESCRIPTION
When transferCurrentComplicationUserInfo fails on iOS (e.g., no watch paired, no complications configured, or daily transfer limit exceeded), the didFinishUserInfoTransfer:error: delegate method is called with an NSError.

Both of these can return nil and NSDictionary cannot contain nil values causing a crash.

The fix adds empty directories as a fallback when error or transferUserInfo is nil.